### PR TITLE
Fix shields to properly use the GitHub workflow status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 ![Bebop logo; The word Bebop, but the second B is replaced with a saxophone with ones and zeros coming out of it.](./assets/header.jpg)
 
-[![Compiler Build](https://img.shields.io/github/workflow/status/RainwayApp/bebop/build-bebopc?label=Compiler%20Build)](https://github.com/RainwayApp/bebop/actions/workflows/build-bebopc.yml)
-[![REPL Build](https://img.shields.io/github/workflow/status/RainwayApp/bebop/Bebop%20WebAssembly%20REPL?label=REPL%20Build)](https://github.com/RainwayApp/bebop/actions/workflows/build-repl.yml)
-[![Integration Tests](https://img.shields.io/github/workflow/status/RainwayApp/bebop/Integration%20Tests?label=Integration%20Tests)](https://github.com/RainwayApp/bebop/actions/workflows/integration-tests.yml)
+[![Compiler Build](https://img.shields.io/github/actions/workflow/status/RainwayApp/bebop/build-bebopc.yml?branch=master)](https://github.com/RainwayApp/bebop/actions/workflows/build-bebopc.yml)
+[![REPL Build](https://img.shields.io/github/actions/workflow/status/RainwayApp/bebop/build-repl.yml?branch=master)](https://github.com/RainwayApp/bebop/actions/workflows/build-repl.yml)
+[![Integration Tests](https://img.shields.io/github/actions/workflow/status/RainwayApp/bebop/integration-tests.yml?branch=master)](https://github.com/RainwayApp/bebop/actions/workflows/integration-tests.yml)
 
-[![Test .NET](https://img.shields.io/github/workflow/status/RainwayApp/bebop/Bebop%20.NET%20Runtime?label=Test%20.NET)](https://github.com/RainwayApp/bebop/actions/workflows/build-runtime-cs.yml)
-[![Test Rust](https://img.shields.io/github/workflow/status/RainwayApp/bebop/Test%20Rust?label=Test%20Rust)](https://github.com/RainwayApp/bebop/actions/workflows/test-rust.yml)
-[![Test TypeScript](https://img.shields.io/github/workflow/status/RainwayApp/bebop/Test%20TypeScript?label=Test%20TypeScript)](https://github.com/RainwayApp/bebop/actions/workflows/test-typescript.yml)
-[![Test Dart](https://img.shields.io/github/workflow/status/RainwayApp/bebop/Test%20Dart?label=Test%20Dart)](https://github.com/RainwayApp/bebop/actions/workflows/test-dart.yml)
+[![Test .NET](https://img.shields.io/github/actions/workflow/status/RainwayApp/bebop/build-runtime-cs.yml?branch=master)](https://github.com/RainwayApp/bebop/actions/workflows/build-runtime-cs.yml)
+[![Test Rust](https://img.shields.io/github/actions/workflow/status/RainwayApp/bebop/test-rust.yml?branch=master)](https://github.com/RainwayApp/bebop/actions/workflows/test-rust.yml)
+[![Test TypeScript](https://img.shields.io/github/actions/workflow/status/RainwayApp/bebop/test-typescript.yml?branch=master)](https://github.com/RainwayApp/bebop/actions/workflows/test-typescript.yml)
+[![Test Dart](https://img.shields.io/github/actions/workflow/status/RainwayApp/bebop/test-dart.yml?branch=master)](https://github.com/RainwayApp/bebop/actions/workflows/test-dart.yml)
 
 Bebop is a schema-based binary serialization technology, similar to Protocol Buffers or MessagePack. In particular, Bebop tries to be a good fit for client–server or distributed web apps that need something faster, more concise, and more type-safe than JSON or MessagePack, while also avoiding some of the complexity of Protocol Buffers, FlatBuffers and the like.
 


### PR DESCRIPTION
The fix was made according to this issue: https://github.com/badges/shields/issues/8671

Before:
![image](https://user-images.githubusercontent.com/962989/235932323-8d636198-6314-4a47-90ff-d543ad891d12.png)


After:
![image](https://user-images.githubusercontent.com/962989/235932424-c06a25af-1e2b-4556-9212-1eb2d6435627.png)
