### PR TITLE
deprecate 'readonly' modifier

### DIFF
--- a/Core/Exceptions/Exceptions.cs
+++ b/Core/Exceptions/Exceptions.cs
@@ -322,4 +322,12 @@ namespace Core.Exceptions
             : base($"Bebop recommends that 0 in an enum be reserved for a value named 'Unknown', 'Default', or similar. See https://github.com/RainwayApp/bebop/wiki/Why-should-0-be-a-%22boring%22-value-in-an-enum%3F for more info.", field.Span, 200, Severity.Warning)
         { }
     }
+
+    [Serializable]
+    public class DeprecatedFeatureWarning : SpanException
+    {
+        public DeprecatedFeatureWarning(Span span, string reason)
+            : base(reason, span, 201, Severity.Warning)
+        { }
+    }
 }


### PR DESCRIPTION
The compiler will now produce a warning that the 'readonly' modifier is deprecated and will be removed in 3.0:

```shell
Warning [BOP201]: DeprecatedFeatureWarning
   ┌─[/Users/andrew/projects/bebop/Compiler/test.bop]
   │
 6 │     1-> readonly struct Test {
   ·         ────┬───              
   ·             ╰───────────────── the 'readonly' modifier will be removed in the next major version of Bebop; structs will be immutable by default, and the 'mut' modifier will be added to make them mutable.
```

See #201 