### PR TITLE
Invariant globalization fix

### DIFF
--- a/Compiler/Compiler.csproj
+++ b/Compiler/Compiler.csproj
@@ -19,6 +19,7 @@
     <Platforms>AnyCPU</Platforms>
     <Configurations>Debug;Release</Configurations>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -13,6 +13,7 @@
     <VersionPrefix Condition="'$(ReleaseVersion)' == ''">0.0.1</VersionPrefix>
     <VersionSuffix Condition="'$(ReleaseVersion)' == ''">$([System.DateTime]::UtcNow.ToString(`yyyyMMdd-HHmm`))</VersionSuffix>
     <Configurations>Debug;Release</Configurations>
+      <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
 


### PR DESCRIPTION
In certain environments such as Replit and Stackblitz bebopc fails because it cannot find a culture file. This fixes that.