### PR TITLE
Parsing / validation fixes

### DIFF
--- a/Core/Exceptions/Exceptions.cs
+++ b/Core/Exceptions/Exceptions.cs
@@ -294,14 +294,14 @@ namespace Core.Exceptions
     class InvalidServiceRequestTypeException : SpanException
     {
         public InvalidServiceRequestTypeException(string serviceName, string methodName, TypeBase type, Span span)
-              : base($"The request type of method '{methodName}' in service '{serviceName}' is '{type.AsString}'  must be a message, struct, or union.", span, 132)
+              : base($"The request type of method '{methodName}' in service '{serviceName}' is '{type.AsString}'  must be a defined type of message, struct, or union.", span, 132)
         { }
     }
     [Serializable]
     class InvalidServiceReturnTypeException : SpanException
     {
         public InvalidServiceReturnTypeException(string serviceName, string methodName, TypeBase type, Span span)
-            : base($"The return type of method '{methodName}' in service '{serviceName}' is '{type.AsString}' but must be a message, struct, or union.", span, 133)
+            : base($"The return type of method '{methodName}' in service '{serviceName}' is '{type.AsString}' but must be a defined type of message, struct, or union.", span, 133)
         { }
     }
 

--- a/Core/Exceptions/Exceptions.cs
+++ b/Core/Exceptions/Exceptions.cs
@@ -313,6 +313,14 @@ namespace Core.Exceptions
         { }
     }
 
+    [Serializable]
+    class UnexpectedEndOfFile : SpanException
+    {
+        public UnexpectedEndOfFile(Span span)
+            : base($"Unexpected EOF.", span, 135)
+        { }
+    }
+
 
 
     [Serializable]

--- a/Core/Generators/GeneratorUtils.cs
+++ b/Core/Generators/GeneratorUtils.cs
@@ -76,7 +76,14 @@ namespace Core.Generators
         /// <remarks>
         ///  Used by the <see cref="CSharpGenerator"/> and other languages where classes are pascal case.
         /// </remarks>
-        public static string ClassName(this Definition definition) => definition.Name.ToPascalCase();
+        public static string ClassName(this Definition definition)
+        {
+            if (definition is ServiceDefinition) {
+                return $"{definition.Name.ToPascalCase()}Service";
+            }
+            return definition.Name.ToPascalCase();
+        }
+
         /// <summary>
         /// Gets the formatted base class name for a <see cref="Definition"/>.
         /// </summary>
@@ -84,7 +91,13 @@ namespace Core.Generators
         /// <remarks>
         ///  Used by the <see cref="CSharpGenerator"/> and other languages where "Base" indicates a class that can be inherited.
         /// </remarks>
-        public static string BaseClassName(this Definition definition) => $"Base{definition.Name.ToPascalCase()}";
+        public static string BaseClassName(this Definition definition)
+        {
+            if (definition is ServiceDefinition) {
+                return $"Base{definition.Name.ToPascalCase()}Service";
+            }
+            return $"Base{definition.Name.ToPascalCase()}";
+        }
 
         /// <summary>
         /// Gets the generic argument index for a branch of a union.

--- a/Core/Generators/TypeScript/TypeScriptGenerator.cs
+++ b/Core/Generators/TypeScript/TypeScriptGenerator.cs
@@ -684,7 +684,7 @@ namespace Core.Generators.TypeScript
                                 builder.AppendLine($"service = TempoServiceRegistry.tryGetService(serviceName);");
                                 builder.CodeBlock($"if (!(service instanceof {service.BaseClassName()}))", indentStep, () =>
                                 {
-                                    builder.AppendLine("throw new Error('todo');");
+                                    builder.AppendLine("throw new Error(`No service named '${serviceName}'was registered with the TempoServiceRegistry`);");
                                 });
                                 builder.AppendLine($"service.setLogger(this.logger.clone(serviceName));");
                                 builder.AppendLine("TempoServiceRegistry.staticServiceInstances.delete(serviceName);");

--- a/Core/Meta/BebopSchema.cs
+++ b/Core/Meta/BebopSchema.cs
@@ -187,6 +187,10 @@ namespace Core.Meta
                         {
                             errors.Add(new DuplicateFieldException(field, fd));
                         }
+                        if (field.Type is DefinedType st && Definitions.TryGetValue(st.Name, out var std) && std is ServiceDefinition)
+                        {
+                            errors.Add(new InvalidFieldException(field, "Field cannot be a service"));
+                        }
                         switch (fd)
                         {
                             case StructDefinition when field.Type is DefinedType dt && fd.Name.Equals(dt.Name):
@@ -229,11 +233,11 @@ namespace Core.Meta
                         {
                             errors.Add(new DuplicateServiceMethodIdException(b.Id, sd.Name, fnd.Name, fnd.Span));
                         }
-                        if (!fnd.RequestDefinition.IsAggregate(this))
+                        if (fnd.RequestDefinition.IsDefined(this) && !fnd.RequestDefinition.IsAggregate(this))
                         {
                             errors.Add(new InvalidServiceRequestTypeException(sd.Name, fnd.Name, fnd.RequestDefinition, fnd.Span));
                         }
-                        if (!fnd.ReturnDefintion.IsAggregate(this))
+                        if (fnd.ReturnDefintion.IsDefined(this) && !fnd.ReturnDefintion.IsAggregate(this))
                         {
                             errors.Add(new InvalidServiceReturnTypeException(sd.Name, fnd.Name, fnd.ReturnDefintion, fnd.Span));
                         }

--- a/Core/Meta/Type.cs
+++ b/Core/Meta/Type.cs
@@ -146,6 +146,9 @@ namespace Core.Meta
             return type is DefinedType dt && schema.Definitions[dt.Name] is UnionDefinition;
         }
 
+        public static bool IsDefined(this TypeBase type, BebopSchema schema) {
+            return type is DefinedType dt && schema.Definitions.ContainsKey(dt.Name);
+        }
         public static bool IsAggregate(this TypeBase type, BebopSchema schema)
         {
             return IsUnion(type, schema) || IsMessage(type, schema) || IsStruct(type, schema);

--- a/Laboratory/Schemas/ShouldFail/bad_comment.bop
+++ b/Laboratory/Schemas/ShouldFail/bad_comment.bop
@@ -1,0 +1,1 @@
+/** I didn't close the block comment

--- a/Laboratory/Schemas/Valid/empty.bop
+++ b/Laboratory/Schemas/Valid/empty.bop
@@ -1,0 +1,1 @@
+/** I am an empty file */


### PR DESCRIPTION
- Improved the parsing and validation of service definitions
  - Made it so service definitions can't be assigned as a field of another definition
  - Properly assign the parent for method request and return types 
  - Checks if types are undefined inside of service methods 
  -  Fixed an exception that would throw in the compiler as you type a service definition
- Improved block comment parsing
  - A .bop file that ends with a block comment is now valid
  - A .bop file which only contains a block comment is now valid
  - The compiler no longer throws an exception when a block comment is incomplete; instead it raises an Unexpected EOF diagnostic

The improved REPL and watch mode are helping catch a lot of hard crashes in the compiler. The goal is to get to a point where there are no raw exceptions - if the compiler detects something with the schema, it should report it as a diagnostic.