### PR TITLE
repl: monarch grammar

### DIFF
--- a/Repl/Pages/Index.razor
+++ b/Repl/Pages/Index.razor
@@ -67,7 +67,7 @@
 	{
 		AutomaticLayout = true,
         Theme = "vs-dark",
-		Language = "c",
+		Language = "bebop",
 		Value = "struct Point { int32 x; int32 y; }",
         FontLigatures = true,
         FormatOnType = true,
@@ -95,6 +95,12 @@
         }
 	};
 }
+
+protected override async Task OnInitializedAsync()
+{
+       await JS.InvokeVoidAsync("registerBebop");
+}
+
 }
 
 @functions {

--- a/Repl/wwwroot/index.html
+++ b/Repl/wwwroot/index.html
@@ -16,21 +16,21 @@
     <link href="Repl.styles.css" rel="stylesheet" />
     <script>
       window.assemblyName = "Repl";
-      window.disableError = async (editorId)  =>{
-        var editor = blazorMonaco.editors.find(x => x.id === editorId).editor;
+      window.disableError = async (editorId) => {
+        var editor = blazorMonaco.editors.find((x) => x.id === editorId).editor;
         var model = await editor.getModel();
         // Clear the markers on the model by passing an empty array
         monaco.editor.setModelMarkers(model, "error", []);
       };
       window.clearMarkers = async (editorId) => {
-        var editor = blazorMonaco.editors.find(x => x.id === editorId).editor;
+        var editor = blazorMonaco.editors.find((x) => x.id === editorId).editor;
         var model = await editor.getModel();
-        monaco.editor.setModelMarkers(model,"bebop", []);
-      }
+        monaco.editor.setModelMarkers(model, "bebop", []);
+      };
       window.setMarkers = async (editorId, markers) => {
-        var editor = blazorMonaco.editors.find(x => x.id === editorId).editor;
+        var editor = blazorMonaco.editors.find((x) => x.id === editorId).editor;
         var model = await editor.getModel();
-        monaco.editor.setModelMarkers(model,"bebop", markers);
+        monaco.editor.setModelMarkers(model, "bebop", markers);
       };
       window.hasExampleParam = function () {
         var url_string = "http://www.example.com/t.html?a=1&b=3&c=m2-m3-m4-m5"; //window.location.href
@@ -45,6 +45,134 @@
         );
         const schemaTextArea = document.getElementById("schema");
         schemaTextArea.value = exampleSchema;
+      };
+      window.registerBebop = () => {
+        monaco.languages.register({ id: "bebop", extensions: [".bop"], aliases: ["Bebop"] });
+        monaco.languages.setMonarchTokensProvider("bebop", {
+          keywords: [
+            "import",
+            "const",
+            "message",
+            "union",
+            "struct",
+            "enum",
+            "true",
+            "false",
+            "inf",
+            "-inf",
+            "nan",
+            "readonly",
+            "mut",
+            "service",
+            "stream",
+            "deprecated",
+            "flags",
+            "opcode",
+          ],
+
+          typeKeywords: [
+            "bool",
+            "byte",
+            "uint8",
+            "uint16",
+            "int16",
+            "uint32",
+            "int32",
+            "uint64",
+            "int64",
+            "float32",
+            "float64",
+            "string",
+            "guid",
+          ],
+
+          operators: ["=", "->"],
+
+          // we include these common regular expressions
+          symbols: /[=><!~?:&|+\-*\/\^%]+/,
+
+          // C# style strings
+          escapes:
+            /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
+
+          // The main tokenizer for our languages
+          tokenizer: {
+            root: [
+              // identifiers and keywords
+              [
+                /[a-z_$][\w$]*/,
+                {
+                  cases: {
+                    "@typeKeywords": "keyword",
+                    "@keywords": "keyword",
+                    "@default": "identifier",
+                  },
+                },
+              ],
+              [/[A-Z][\w\$]*/, "type.identifier"], // to show class names nicely
+
+              // whitespace
+              { include: "@whitespace" },
+
+              // delimiters and operators
+              [/[{}()\[\]]/, "@brackets"],
+              [/[<>](?!@symbols)/, "@brackets"],
+              [
+                /@symbols/,
+                { cases: { "@operators": "operator", "@default": "" } },
+              ],
+
+              // @ annotations.
+              // As an example, we emit a debugging log message on these tokens.
+              // Note: message are supressed during the first load -- change some lines to see them.
+              [
+                /@\s*[a-zA-Z_\$][\w\$]*/,
+                { token: "annotation", log: "annotation token: $0" },
+              ],
+
+              // numbers
+              [/\d*\.\d+([eE][\-+]?\d+)?/, "number.float"],
+              [/0[xX][0-9a-fA-F]+/, "number.hex"],
+              [/\d+/, "number"],
+
+              // delimiter: after number because of .\d floats
+              [/[;,.]/, "delimiter"],
+
+              // strings
+              [/"([^"\\]|\\.)*$/, "string.invalid"], // non-teminated string
+              [
+                /"/,
+                { token: "string.quote", bracket: "@open", next: "@string" },
+              ],
+
+              // characters
+              [/'[^\\']'/, "string"],
+              [/(')(@escapes)(')/, ["string", "string.escape", "string"]],
+              [/'/, "string.invalid"],
+            ],
+
+            comment: [
+              [/[^\/*]+/, "comment"],
+              [/\/\*/, "comment", "@push"], // nested comment
+              ["\\*/", "comment", "@pop"],
+              [/[\/*]/, "comment"],
+            ],
+
+            string: [
+              [/[^\\"]+/, "string"],
+              [/[']+/, "string"],
+              [/@escapes/, "string.escape"],
+              [/\\./, "string.escape.invalid"],
+              [/"/, { token: "string.quote", bracket: "@close", next: "@pop" }],
+            ],
+
+            whitespace: [
+              [/[ \t\r\n]+/, "white"],
+              [/\/\*/, "comment", "@comment"],
+              [/\/\/.*$/, "comment"],
+            ],
+          },
+        });
       };
     </script>
   </head>


### PR DESCRIPTION
Adds a basic Bebop schema grammar to give syntax highlighting to the schema editor on the REPL
<img width="729" alt="" src="https://github.com/betwixt-labs/bebop/assets/1297077/cdd88853-5674-43e1-91d2-b1ad3e5b1087">
