### PR TITLE
feat(ts-gen): typeguard helpers for unions

### DIFF
--- a/Core/Generators/TypeScript/TypeScriptGenerator.cs
+++ b/Core/Generators/TypeScript/TypeScriptGenerator.cs
@@ -666,8 +666,9 @@ namespace Core.Generators.TypeScript
                 builder.Indent(2);
             }
 
-            if (emitBinarySchema) {
-               
+            if (emitBinarySchema)
+            {
+
                 builder.AppendLine($"export {Schema.ToBinary().ConvertToTypeScriptUInt8ArrayInitializer("BEBOP_SCHEMA")}");
                 builder.AppendLine();
             }
@@ -811,7 +812,12 @@ namespace Core.Generators.TypeScript
                             {
                                 builder.CodeBlock($"public static from{b.ClassName()}(value: I{b.ClassName()})", indentStep, () =>
                                 {
-                                    builder.AppendLine($"return new {definition.ClassName()}({{ discriminator: {b.Discriminator}, value: new {b.ClassName()}(value)}});");
+                                    builder.AppendLine($"return new {definition.ClassName()}({{ discriminator: {b.Discriminator}, value: new {b.ClassName()}(value)}});"    );
+                                });
+                                builder.AppendLine();
+                                builder.CodeBlock($"public is{b.ClassName()}(): this is {{ value: {b.ClassName()} }} & {{ data: Extract<I{ud.ClassName()}Type, {{ discriminator: {b.Discriminator} }}> }}", indentStep, () =>
+                                {
+                                    builder.AppendLine($"return this.data.value instanceof {b.ClassName()};");
                                 });
                                 builder.AppendLine();
                             }


### PR DESCRIPTION
this change introduces helper functions that allow you to identify the underlying type of a union in a way that populates information to the type system.

```typescript
const test = Test.fromA({hello: "world"});
if (test.isA()) {
    // typescript knows that 'value' is 'A'
    console.log(test.value.hello)
   // it also knows that 'data' is { discriminator: 1, value: IA }
    console.log(test.data.value.hello)
}
```