### PR TITLE
chore: align integration test

### DIFF
--- a/Laboratory/Integration/Program.cs
+++ b/Laboratory/Integration/Program.cs
@@ -39,12 +39,12 @@ static Library MakeLibrary()
                         new[]
                         {
                             new Song("Giant Steps", 1959,
-                                new[] { new Musician("John Coltrane", Instrument.Piano) }),
+                                new[] { new Musician("John Coltrane", Instrument.Piano, Guid.Parse("ff990458-a276-4b71-b2e3-57d49470b949")) }),
                             new Song("A Night in Tunisia", 1942,
                                 new[]
                                 {
-                                    new Musician("Dizzy Gillespie", Instrument.Trumpet),
-                                    new Musician("Count Basie", Instrument.Piano)
+                                    new Musician("Dizzy Gillespie", Instrument.Trumpet, Guid.Parse("84f4b320-0f1e-463e-982c-78772fabd74d")),
+                                    new Musician("Count Basie", Instrument.Piano, Guid.Parse("b28d54d6-a3f7-48bf-a07a-117c15cf33ef"))
                                 }),
                             new Song("Groovin' High", null, null)
                         }
@@ -57,9 +57,9 @@ static Library MakeLibrary()
                             new Song(null, 1965,
                                 new[]
                                 {
-                                    new Musician("Carmell Jones", Instrument.Trumpet),
-                                    new Musician("Joe Henderson", Instrument.Sax),
-                                    new Musician("Teddy Smith", Instrument.Clarinet)
+                                    new Musician("Carmell Jones", Instrument.Trumpet, Guid.Parse("f7c31724-0387-4ac9-b6f0-361bb9415c1b")),
+                                    new Musician("Joe Henderson", Instrument.Sax, Guid.Parse("bb4facf3-c65a-46dd-a96f-73ca6d1cf3f6")),
+                                    new Musician("Teddy Smith", Instrument.Clarinet, Guid.Parse("91ffb47f-2a38-4876-8186-1f267cc21706"))
                                 })
                         }, "Night's Palace", null)
                 });
@@ -80,6 +80,7 @@ static void ValidateLibrary(Library lib)
                 Debug.Assert(performers?.Length == 1);
                 Debug.Assert(performers[0].Name == "John Coltrane");
                 Debug.Assert(performers[0].Plays == Instrument.Piano);
+                Debug.Assert(performers[0].ID == Guid.Parse("ff990458-a276-4b71-b2e3-57d49470b949"));
             }
         }
         {
@@ -91,8 +92,10 @@ static void ValidateLibrary(Library lib)
                 Debug.Assert(performers?.Length == 2);
                 Debug.Assert(performers[0].Name == "Dizzy Gillespie");
                 Debug.Assert(performers[0].Plays == Instrument.Trumpet);
+                Debug.Assert(performers[0].ID == Guid.Parse("84f4b320-0f1e-463e-982c-78772fabd74d"));
                 Debug.Assert(performers[1].Name == "Count Basie");
                 Debug.Assert(performers[1].Plays == Instrument.Piano);
+                Debug.Assert(performers[1].ID == Guid.Parse("b28d54d6-a3f7-48bf-a07a-117c15cf33ef"));
             }
         }
         {
@@ -125,9 +128,12 @@ static void ValidateLibrary(Library lib)
         Debug.Assert(performers?.Length == 3);
         Debug.Assert(performers[0].Name == "Carmell Jones");
         Debug.Assert(performers[0].Plays == Instrument.Trumpet);
+        Debug.Assert(performers[0].ID == Guid.Parse("f7c31724-0387-4ac9-b6f0-361bb9415c1b"));
         Debug.Assert(performers[1].Name == "Joe Henderson");
         Debug.Assert(performers[1].Plays == Instrument.Sax);
+        Debug.Assert(performers[1].ID == Guid.Parse("bb4facf3-c65a-46dd-a96f-73ca6d1cf3f6"));
         Debug.Assert(performers[2].Name == "Teddy Smith");
         Debug.Assert(performers[2].Plays == Instrument.Clarinet);
+        Debug.Assert(performers[2].ID == Guid.Parse("91ffb47f-2a38-4876-8186-1f267cc21706"));
     }
 }

--- a/Laboratory/Integration/Rust/src/lib.rs
+++ b/Laboratory/Integration/Rust/src/lib.rs
@@ -1,6 +1,7 @@
 mod schema;
 pub use schema::*;
 use bebop::prelude::*;
+use std::str::FromStr;
 
 pub fn make_library() -> Library<'static> {
     Library {
@@ -13,7 +14,8 @@ pub fn make_library() -> Library<'static> {
                         performers: Some(vec![
                             Musician {
                                 name: "John Coltrane",
-                                plays: Instrument::Piano
+                                plays: Instrument::Piano,
+                                id: bebop::Guid::from_str("ff990458-a276-4b71-b2e3-57d49470b949").unwrap(),
                             }
                         ])
                     },
@@ -24,10 +26,12 @@ pub fn make_library() -> Library<'static> {
                             Musician {
                                 name: "Dizzy Gillespie",
                                 plays: Instrument::Trumpet,
+                                id: bebop::Guid::from_str("84f4b320-0f1e-463e-982c-78772fabd74d").unwrap(),
                             },
                             Musician {
                                 name: "Count Basie",
                                 plays: Instrument::Piano,
+                                id: bebop::Guid::from_str("b28d54d6-a3f7-48bf-a07a-117c15cf33ef").unwrap(),
                             },
                         ])
                     },
@@ -57,14 +61,17 @@ pub fn make_library() -> Library<'static> {
                             Musician {
                                 name: "Carmell Jones",
                                 plays: Instrument::Trumpet,
+                                id: bebop::Guid::from_str("f7c31724-0387-4ac9-b6f0-361bb9415c1b").unwrap(),
                             },
                             Musician {
                                 name: "Joe Henderson",
                                 plays: Instrument::Sax,
+                                id: bebop::Guid::from_str("bb4facf3-c65a-46dd-a96f-73ca6d1cf3f6").unwrap(),
                             },
                             Musician {
                                 name: "Teddy Smith",
                                 plays: Instrument::Clarinet,
+                                id: bebop::Guid::from_str("91ffb47f-2a38-4876-8186-1f267cc21706").unwrap(),
                             },
                         ])
                     }

--- a/Laboratory/Integration/makelib.hpp
+++ b/Laboratory/Integration/makelib.hpp
@@ -11,11 +11,11 @@ Library make_library() {
         std::map<std::string, Album> {
             {"Giant Steps", { StudioAlbum {{
                 Song {"Giant Steps", 1959, std::vector<Musician> {
-                    Musician {"John Coltrane", Instrument::Piano}
+                    Musician {"John Coltrane", Instrument::Piano, ::bebop::Guid::fromString("ff990458-a276-4b71-b2e3-57d49470b949")}
                 } },
                 Song {"A Night in Tunisia", 1942, std::vector<Musician> {
-                    Musician {"Dizzy Gillespie", Instrument::Trumpet},
-                    Musician {"Count Basie", Instrument::Piano}
+                    Musician {"Dizzy Gillespie", Instrument::Trumpet, ::bebop::Guid::fromString("84f4b320-0f1e-463e-982c-78772fabd74d") },
+                    Musician {"Count Basie", Instrument::Piano, ::bebop::Guid::fromString("b28d54d6-a3f7-48bf-a07a-117c15cf33ef") }
                 }},
                 Song {"Groovin' High", {}, {}}
             }}}},
@@ -30,9 +30,9 @@ Library make_library() {
             {"Brilliant Corners", {LiveAlbum {
                 std::vector<Song> {
                     Song { {}, 1965, std::vector<Musician> {
-                        Musician { "Carmell Jones", Instrument::Trumpet },
-                        Musician { "Joe Henderson", Instrument::Sax },
-                        Musician { "Teddy Smith", Instrument::Clarinet }
+                        Musician { "Carmell Jones", Instrument::Trumpet, ::bebop::Guid::fromString("f7c31724-0387-4ac9-b6f0-361bb9415c1b") },
+                        Musician { "Joe Henderson", Instrument::Sax, ::bebop::Guid::fromString("bb4facf3-c65a-46dd-a96f-73ca6d1cf3f6") },
+                        Musician { "Teddy Smith", Instrument::Clarinet, ::bebop::Guid::fromString("91ffb47f-2a38-4876-8186-1f267cc21706") }
                     }},
                 },
                 "Night's Palace",
@@ -56,6 +56,7 @@ void is_valid(Library &lib) {
                 assert(performers.size() == 1);
                 assert(performers[0].name == "John Coltrane");
                 assert(performers[0].plays == Instrument::Piano);
+                assert(performers[0].id == ::bebop::Guid::fromString("ff990458-a276-4b71-b2e3-57d49470b949"));
             }
         }
         {
@@ -67,8 +68,10 @@ void is_valid(Library &lib) {
                 assert(performers.size() == 2);
                 assert(performers[0].name == "Dizzy Gillespie");
                 assert(performers[0].plays == Instrument::Trumpet);
+                assert(performers[0].id == ::bebop::Guid::fromString("84f4b320-0f1e-463e-982c-78772fabd74d"));
                 assert(performers[1].name == "Count Basie");
                 assert(performers[1].plays == Instrument::Piano);
+                assert(performers[1].id == ::bebop::Guid::fromString("b28d54d6-a3f7-48bf-a07a-117c15cf33ef"));
             }
         }
         {
@@ -101,9 +104,12 @@ void is_valid(Library &lib) {
         assert(performers.size() == 3);
         assert(performers[0].name == "Carmell Jones");
         assert(performers[0].plays == Instrument::Trumpet);
+        assert(performers[0].id == ::bebop::Guid::fromString("f7c31724-0387-4ac9-b6f0-361bb9415c1b"));
         assert(performers[1].name == "Joe Henderson");
         assert(performers[1].plays == Instrument::Sax);
+        assert(performers[1].id == ::bebop::Guid::fromString("bb4facf3-c65a-46dd-a96f-73ca6d1cf3f6"));
         assert(performers[2].name == "Teddy Smith");
         assert(performers[2].plays == Instrument::Clarinet);
+        assert(performers[2].id == ::bebop::Guid::fromString("91ffb47f-2a38-4876-8186-1f267cc21706"));
     }
 }

--- a/Laboratory/Integration/makelib.ts
+++ b/Laboratory/Integration/makelib.ts
@@ -1,4 +1,5 @@
-﻿import { Library, ILibrary, Instrument, Album, Song } from "./schema"
+﻿import { Guid } from "bebop";
+import { Library, ILibrary, Instrument, Album, Song } from "./schema"
 
 export function makelib(): Library {
     return new Library({
@@ -8,14 +9,14 @@ export function makelib(): Library {
                     new Song({
                         title: "Giant Steps",
                         year: 1959,
-                        performers: [{ name: "John Coltrane", plays: Instrument.Piano }],
+                        performers: [{ name: "John Coltrane", plays: Instrument.Piano, id: Guid.parseGuid("ff990458-a276-4b71-b2e3-57d49470b949")}],
                     }),
                     new Song({
                         title: "A Night in Tunisia",
                         year: 1942,
                         performers: [
-                            { name: "Dizzy Gillespie", plays: Instrument.Trumpet },
-                            { name: "Count Basie", plays: Instrument.Piano },
+                            { name: "Dizzy Gillespie", plays: Instrument.Trumpet, id: Guid.parseGuid("84f4b320-0f1e-463e-982c-78772fabd74d") },
+                            { name: "Count Basie", plays: Instrument.Piano, id: Guid.parseGuid("b28d54d6-a3f7-48bf-a07a-117c15cf33ef") },
                         ]
                     }),
                     new Song({
@@ -38,9 +39,9 @@ export function makelib(): Library {
                     new Song({
                         year: 1965,
                         performers: [
-                            { name: "Carmell Jones", plays: Instrument.Trumpet },
-                            { name: "Joe Henderson", plays: Instrument.Sax },
-                            { name: "Teddy Smith", plays: Instrument.Clarinet }
+                            { name: "Carmell Jones", plays: Instrument.Trumpet, id: Guid.parseGuid("f7c31724-0387-4ac9-b6f0-361bb9415c1b") },
+                            { name: "Joe Henderson", plays: Instrument.Sax, id: Guid.parseGuid("bb4facf3-c65a-46dd-a96f-73ca6d1cf3f6") },
+                            { name: "Teddy Smith", plays: Instrument.Clarinet,  id: Guid.parseGuid("91ffb47f-2a38-4876-8186-1f267cc21706") }
                         ]
                     })
                 ]

--- a/Laboratory/Integration/schema.bop
+++ b/Laboratory/Integration/schema.bop
@@ -1,14 +1,15 @@
-enum Instrument {
-    Sax = 0;
-    Trumpet = 1;
-    Clarinet = 2;
+enum Instrument : uint16 {
+    Sax = 10;
+    Trumpet = 20;
+    Clarinet = 40;
     /* Just to make sure they all handle this correctly... */
-    Piano = 8;
+    Piano = 80;
 }
 
 readonly struct Musician {
     string name;
     Instrument plays;
+    guid id;
 }
 
 message Song {


### PR DESCRIPTION
the integration test schema didn't utilize `guid` or other new schema language features; this change updates test so they can catch issues from new targets.