### PR TITLE
Move rust benchmark profile

### DIFF
--- a/Laboratory/Rust/Cargo.toml
+++ b/Laboratory/Rust/Cargo.toml
@@ -5,3 +5,7 @@ members = [
     "functionality-testing",
     "benchmarking"
 ]
+
+[profile.bench]
+lto = true
+codegen-units = 1

--- a/Laboratory/Rust/benchmarking/Cargo.toml
+++ b/Laboratory/Rust/benchmarking/Cargo.toml
@@ -11,10 +11,6 @@ harness = false
 name = "flamegraph"
 required-features = ["pprof"]
 
-[profile.bench]
-lto = true
-codegen-units = 1
-
 # Use exact versions for all things being tested
 [dependencies]
 bebop = { path = "../../../Runtime/Rust" }


### PR DESCRIPTION
Moves the `[profile.bench]` section to the correct `Cargo.toml` so it is actually applied.

Closes https://github.com/betwixt-labs/bebop/issues/327