### PR TITLE
fix: playground deploy

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -1,13 +1,19 @@
+# Simple workflow for deploying static content to Cloudflare Pages
 name: Deploy Playground
 
 on:
+  # Runs on pushes targeting the default branch
   push:
     branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
+  # Single deploy job since we're just deploying
   deploy:
     runs-on: ubuntu-latest
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:
       contents: read
       deployments: write
@@ -22,7 +28,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "8.0.x" # SDK Version to use; x will use the latest version of the 7.0 channel
           dotnet-quality: 'preview'
 
       - name: Build Playground
@@ -32,11 +38,13 @@ jobs:
           yarn build:site
         working-directory: ./playground/
 
-      - name: Install Wrangler
-        run: npm install -g wrangler
-
-      - name: Deploy with Wrangler
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: |
-          wrangler pages publish ./playground/dist --project-name bebopc-playground --branch master
+      - name: Deploy Playground
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: bebopc-playground
+          directory: ${{github.workspace}}/playground/dist
+          # Optional: Enable this if you want to have GitHub Deployments triggered
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          branch: master

--- a/.gitignore
+++ b/.gitignore
@@ -294,3 +294,4 @@ go.work
 .chord
 dist
 *.chord
+playground/src/bebopc/bebopc.bin

--- a/playground/package.json
+++ b/playground/package.json
@@ -26,7 +26,7 @@
     "dist"
   ],
   "scripts": {
-    "build:compiler": "../scripts/build-wasi.sh && cp -f ../bin/compiler/Release/artifacts/wasi-wasm/AppBundle/bebopc.wasm ./src/bebopc/bebopc.wasm",
+    "build:compiler": "../scripts/build-wasi.sh && cp -f ../bin/compiler/Release/artifacts/wasi-wasm/AppBundle/bebopc.wasm ./src/bebopc/bebopc.bin",
     "dev": "vite",
     "build:site": "NODE_ENV=production yarn build:compiler && vite build",
     "preview:site": "vite preview",

--- a/playground/src/bebopc/worker.ts
+++ b/playground/src/bebopc/worker.ts
@@ -4,7 +4,7 @@ import WASI, { createFileSystem } from "wasi-js";
 import browserBindings from "wasi-js/dist/bindings/browser";
 import { WASIExitError, WASIFileSystem } from "wasi-js/dist/types";
 
-import bebopcWasmUrl from "./bebopc.wasm?url";
+import bebopcWasmUrl from "./bebopc.bin?url";
 import { WorkerResponse } from "./types";
 
 const decoder = new TextDecoder();


### PR DESCRIPTION
What was the issue? Cloudflare compresses .wasm files and doesn't give us the option to disable it; by changing bebopc.wasm to .bin we bypass gzip, and content-length is returned.