### PR TITLE
fix: formatting typo in binary-schema.mdx

### DIFF
--- a/docs/src/content/docs/reference/binary-schema.mdx
+++ b/docs/src/content/docs/reference/binary-schema.mdx
@@ -234,7 +234,7 @@ The compiler omits any `const` definitions to avoid leaking sensitive informatio
 
   - **Kind**: 1-byte integer (`byte`). Where 1=Struct, 2=Message, 3=Union, 4=Enum.
 
-  - ** Decorators**: see [Decorators](#decorators).
+  - **Decorators**: see [Decorators](#decorators).
 
   - **Definition**: Depends on the kind.
 - **Service Count**: 1-byte integer (`byte`).


### PR DESCRIPTION
Was reading through the docs and noticed what seems to be a formatting typo 🤷🏻