### PR TITLE
Add multi-level namespace support in C++ generator

### DIFF
--- a/Core/Generators/CPlusPlus/CPlusPlusGenerator.cs
+++ b/Core/Generators/CPlusPlus/CPlusPlusGenerator.cs
@@ -376,9 +376,15 @@ namespace Core.Generators.CPlusPlus
             builder.AppendLine("#include \"bebop.hpp\"");
             builder.AppendLine("");
 
+            string[] namespaces = {};
             if (!string.IsNullOrWhiteSpace(Config.Namespace))
             {
-                builder.AppendLine($"namespace {Config.Namespace} {{");
+                namespaces = Config.Namespace.Split("::");
+            }
+
+            foreach (string ns in namespaces)
+            {
+                builder.AppendLine($"namespace {ns} {{");
                 builder.AppendLine("");
             }
 
@@ -510,9 +516,9 @@ namespace Core.Generators.CPlusPlus
                 }
             }
 
-            if (!string.IsNullOrWhiteSpace(Config.Namespace))
+            foreach (string ns in namespaces)
             {
-                builder.AppendLine($"}} // namespace {Config.Namespace}");
+                builder.AppendLine($"}} // namespace {ns}");
                 builder.AppendLine("");
             }
 

--- a/Core/Meta/Extensions/StringExtensions.cs
+++ b/Core/Meta/Extensions/StringExtensions.cs
@@ -484,7 +484,7 @@ namespace Core.Meta.Extensions
         [GeneratedRegex(@"^.*[\*\?\[\]].*(\.[a-zA-Z0-9]+)?$")]
         private static partial Regex LegalFileGlobRegex();
 
-        [GeneratedRegex(@"^[a-zA-Z]+(\.[a-zA-Z]+)*$")]
+        [GeneratedRegex(@"^[a-zA-Z]+(\.[a-zA-Z]+|::[a-zA-Z]+)*$")]
         private static partial Regex NamespaceRegex();
     }
 }


### PR DESCRIPTION
This allows C++ generator to generate multi-level namespaces in generated header file. Additionally, it add supports of using `Namespace1::Namespace2` format in `namespace` configuration.

I avoid using `Namespace1::Namespace2` directly in generated header because it requires C++17.