### PR TITLE
Fix Bebop.cmake unable to handle multiple targets

### DIFF
--- a/Tools/cmake/Bebop.cmake
+++ b/Tools/cmake/Bebop.cmake
@@ -43,7 +43,8 @@ function(Bebop_Generate target_name)
     elseif(_system_processor STREQUAL "arm64")
         set(_system_processor "arm64")
     endif()
-   
+
+    FetchContent_GetProperties(${_bebopc_prefix})
     if(NOT ${_bebopc_prefix}_POPULATED)
         if(CMAKE_HOST_WIN32)
             string(APPEND _bebopc_executable_name ".exe")


### PR DESCRIPTION
`${_bebopc_prefix}_POPULATED` is somehow does not return `true` when setting up multiple targets.  
Adding `FetchContent_GetProperties` fix the issue.