### PR TITLE
Features: Add C# binary schema constant

### DIFF
--- a/Core/Generators/CSharp/CSharpGenerator.cs
+++ b/Core/Generators/CSharp/CSharpGenerator.cs
@@ -46,12 +46,17 @@ namespace Core.Generators.CSharp
                 builder.Indent(indentStep).AppendLine();
             }
 
-            if (Schema.Definitions.Values.Any(d => d is ConstDefinition))
+            if (Config.EmitBinarySchema || Schema.Definitions.Values.Any(d => d is ConstDefinition))
             {
                 builder.AppendLine(ConstantSummary);
                 builder.AppendLine(GeneratedAttribute);
                 builder.AppendLine($"public static class BopConstants {{");
                 builder.Indent(indentStep);
+
+                if (Config.EmitBinarySchema)
+                {
+                    builder.AppendLine(Schema.ToBinary().ConvertToString("public static readonly byte[] BEBOP_SCHEMA = new byte[] {", "};"));
+                }
 
                 foreach (ConstDefinition cd in Schema.Definitions.Values.Where(d => d is ConstDefinition))
                 {
@@ -65,9 +70,6 @@ namespace Core.Generators.CSharp
                 builder.Dedent(indentStep);
                 builder.AppendLine("}").AppendLine();
             }
-
-
-
 
             foreach (var definition in Schema.Definitions.Values)
             {

--- a/Core/Generators/TypeScript/TypeScriptGenerator.cs
+++ b/Core/Generators/TypeScript/TypeScriptGenerator.cs
@@ -678,9 +678,7 @@ namespace Core.Generators.TypeScript
 
             if (Config.EmitBinarySchema)
             {
-
-                builder.AppendLine($"export {Schema.ToBinary().ConvertToTypeScriptUInt8ArrayInitializer("BEBOP_SCHEMA")}");
-                builder.AppendLine();
+                builder.AppendLine(Schema.ToBinary().ConvertToString("export const BEBOP_SCHEMA = new Uint8Array ([", "]);"));
             }
 
             foreach (var definition in Schema.Definitions.Values)

--- a/Core/Meta/Extensions/StringExtensions.cs
+++ b/Core/Meta/Extensions/StringExtensions.cs
@@ -258,10 +258,10 @@ namespace Core.Meta.Extensions
             }
         }
 
-        public static string ConvertToTypeScriptUInt8ArrayInitializer(this byte[] byteArray, string propertyName = "schema")
+        public static string ConvertToString(this byte[] byteArray, string leftBrace = "[", string rightBrace = "];")
         {
             StringBuilder builder = new StringBuilder();
-            builder.AppendLine($"const {propertyName} = new Uint8Array([");
+            builder.AppendLine(leftBrace);
 
             int printWidth = 60; // Prettier default print width
             int currentLineWidth = 0;
@@ -288,7 +288,7 @@ namespace Core.Meta.Extensions
 
             // Append a new line to de-indent the closing brackets.
             builder.AppendLine();
-            builder.AppendLine("]);");
+            builder.Append(rightBrace);
 
             return builder.ToString();
         }


### PR DESCRIPTION
This Pull Request refactors the code in TypeScript's binary schema creation and adds the feature to C#. The refactoring was made because the old code reserved the string extension method `byte[].ConvertToTypeScriptUInt8ArrayInitializer(schemaName)`, which was abstracted to `byte[].ConvertToString(leftBrace, rightBrace)`. The new method allows printing out the schema language-independent.

This Pull Request was tested with TypeScript and C#.