### PR TITLE
Fix typo in "getting-started-typescript.mdx" init

### DIFF
--- a/docs/src/content/docs/guide/getting-started-typescript.mdx
+++ b/docs/src/content/docs/guide/getting-started-typescript.mdx
@@ -65,7 +65,7 @@ Initialize your Bebop project:
   <TabItem label="npm">
   
 ```bash
-npx bebopc init
+npx bebopc --init
 ```
 
   </TabItem>
@@ -73,7 +73,7 @@ npx bebopc init
   <TabItem label="yarn">
   
 ```bash
-yarn bebopc init
+yarn bebopc --init
 ```
 
   </TabItem>


### PR DESCRIPTION
This argument is passed as a unix flag.