### PR TITLE
fix/improve rust getting started build.rs example  + add docstring to `Record::serialize`

### DIFF
--- a/Runtime/Rust/src/serialization/mod.rs
+++ b/Runtime/Rust/src/serialization/mod.rs
@@ -43,6 +43,22 @@ pub trait Record<'raw>: SubRecord<'raw> {
     }
 
     /// Serialize this record. It is highly recommend to use a buffered writer.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// // For fixed-size types
+    /// let value: MyFixedSizeType = /* ... */;
+    /// let mut buf = Vec::with_capacity(MyFixedSizeType::SERIALIZED_SIZE);
+    /// let bytes_written = value.serialize(&mut buf).unwrap();
+    /// ```
+    /// ```rust
+    /// // For variable-size types
+    /// let value: MyVariableSizeType = /* ... */;
+    /// let size = value.serialized_size();
+    /// let mut buf = Vec::with_capacity(size);
+    /// let bytes_written = value.serialize(&mut buf)?;
+    /// ```
     #[inline(always)]
     fn serialize<W: Write>(&self, dest: &mut W) -> SeResult<usize> {
         Self::_serialize_chained(self, dest)

--- a/Runtime/Rust/src/serialization/mod.rs
+++ b/Runtime/Rust/src/serialization/mod.rs
@@ -57,7 +57,7 @@ pub trait Record<'raw>: SubRecord<'raw> {
     /// let value: MyVariableSizeType = /* ... */;
     /// let size = value.serialized_size();
     /// let mut buf = Vec::with_capacity(size);
-    /// let bytes_written = value.serialize(&mut buf)?;
+    /// let bytes_written = value.serialize(&mut buf).unwrap();
     /// ```
     #[inline(always)]
     fn serialize<W: Write>(&self, dest: &mut W) -> SeResult<usize> {

--- a/docs/src/content/docs/guide/getting-started-rust.mdx
+++ b/docs/src/content/docs/guide/getting-started-rust.mdx
@@ -22,10 +22,10 @@ fn main() {
     // download the bebop binary automatically and cache it into your target directory
     // it will automatically download the same version as the package you installed
     bebop::download_bebopc(
-        PathBuf::from("target").join("bebopc"),
+        std::path::PathBuf::from("target").join("bebopc"),
     );
     // build all `.bop` schemas in `schemas` dir and make a new module `generated` in `src` with all of them.
-    bebop::build_schema_dir("schemas", "src/generated");
+    bebop::build_schema_dir("schemas", "src/generated", &bebop::BuildConfig::default());
 }
 ```
 


### PR DESCRIPTION
- [x] fixes getting started `build.rs`
- [x] add small docstring to `Record::serialize` to show how to initialize vec with capacity for both `FixedSize` and non `FixedSize` records. 